### PR TITLE
Added ability to pass username and password for Registry Authentication

### DIFF
--- a/src/functionalTest/groovy/nebula/plugin/docker/NebulaDockerPluginTest.groovy
+++ b/src/functionalTest/groovy/nebula/plugin/docker/NebulaDockerPluginTest.groovy
@@ -261,4 +261,62 @@ class NebulaDockerPluginTest extends ProjectSpec {
         project.extensions['docker'].classpath
         //TODO: how to check the list of classpath?
     }
+
+    def "enabling repoAuth and setting the username password and email on docker.registryCredentials"() {
+
+        def x = new NebulaDockerPlugin()
+        x.apply(project)
+        project.configure(project) {
+            apply plugin: 'application'
+            apply plugin: 'distribution'
+            apply plugin: 'com.bmuschko.docker-java-application'
+        }
+        project.applicationName = 'xyz'
+        project.nebulaDocker.dockerFile = 'some docker file'
+        project.nebulaDocker.dockerBase = 'base docker'
+        project.nebulaDocker.maintainerEmail = 'some email'
+        project.nebulaDocker.appDir = 'app directory'
+        project.nebulaDocker.appDirLatest = 'latest directory'
+
+        project.nebulaDocker.dockerRepoAuth = true
+        project.nebulaDocker.dockerRepoUsername = "username"
+        project.nebulaDocker.dockerRepoPassword = "password"
+        project.nebulaDocker.dockerRepoEmail = "joe@bloggs.com"
+
+        when: "triggering a project.evaluate"
+        project.getTasksByName("tasks", false)
+
+        then: "the configurations should be passed through to docker-java-application"
+        project.extensions['docker']
+        project.extensions['docker'].registryCredentials
+        project.extensions['docker'].registryCredentials.username == "username"
+        project.extensions['docker'].registryCredentials.password == "password"
+        project.extensions['docker'].registryCredentials.email == "joe@bloggs.com"
+
+    }
+
+    def "when repoAuth is not explicitly enabled then docker.registryCredentials is not populated"() {
+
+        def x = new NebulaDockerPlugin()
+        x.apply(project)
+        project.configure(project) {
+            apply plugin: 'application'
+            apply plugin: 'distribution'
+            apply plugin: 'com.bmuschko.docker-java-application'
+        }
+        project.applicationName = 'xyz'
+        project.nebulaDocker.dockerFile = 'some docker file'
+        project.nebulaDocker.dockerBase = 'base docker'
+        project.nebulaDocker.maintainerEmail = 'some email'
+        project.nebulaDocker.appDir = 'app directory'
+        project.nebulaDocker.appDirLatest = 'latest directory'
+
+        when: "triggering a project.evaluate"
+        project.getTasksByName("tasks", false)
+
+        then: "dockerRepoAuth should be false, and registryCredentials should be null"
+        !project.nebulaDocker.dockerRepoAuth
+        project.extensions['docker']
+        !project.extensions['docker'].registryCredentials
+    }
 }

--- a/src/main/groovy/nebula/plugin/docker/NebulaDockerExtension.groovy
+++ b/src/main/groovy/nebula/plugin/docker/NebulaDockerExtension.groovy
@@ -90,6 +90,27 @@ class NebulaDockerExtension {
     def Closure<String> tagVersion
 
     /**
+     * This is a simple flag to indicate whether or not to add registryCredentials to the underlying docker extension
+     * for specifying user credentials (default is false)
+     */
+    def boolean dockerRepoAuth
+
+    /**
+     * The registry username (default is null)
+     */
+    def String dockerRepoUsername
+
+    /**
+     * The registry password (default is null)
+     */
+    def String dockerRepoPassword
+
+    /**
+     * The registry email address (default is null)
+     */
+    def String dockerRepoEmail
+
+    /**
      * Defines a property which returns all the environments defined in the {@link #dockerRepo}.
      * This is basically a set of all the keys present in the {@link #dockerRepo} set.
      *

--- a/src/main/groovy/nebula/plugin/docker/NebulaDockerPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/docker/NebulaDockerPlugin.groovy
@@ -139,6 +139,14 @@ class NebulaDockerPlugin implements Plugin<Project>, Strings, NebulaDockerSensib
                     baseImage = nebulaDockerExt.dockerBase
                     maintainer = nebulaDockerExt.maintainerEmail
                 }
+
+                if(nebulaDockerExt.dockerRepoAuth) {
+                    registryCredentials {
+                        username = nebulaDockerExt.dockerRepoUsername
+                        password = nebulaDockerExt.dockerRepoPassword
+                        email = nebulaDockerExt.dockerRepoEmail
+                    }
+                }
             }
 
             createAllTasks project

--- a/src/test/groovy/nebula/plugin/docker/NebulaDockerSensibleDefaultsTest.groovy
+++ b/src/test/groovy/nebula/plugin/docker/NebulaDockerSensibleDefaultsTest.groovy
@@ -49,5 +49,9 @@ class NebulaDockerSensibleDefaultsTest extends Specification {
         ext.dockerFile == x.DEF_DOCKER_FILE
         ext.appDirLatest == "/${appName}-latest"
         ext.appDir == "/${appName}-1.2.3"
+        !ext.dockerRepoAuth
+        ext.dockerRepoUsername == null
+        ext.dockerRepoPassword == null
+        ext.dockerRepoEmail == null
     }
 }


### PR DESCRIPTION
This adds the ability to pass through username/password/email to the registryCredentials block in docker-java.  This feature is configured via the following:

Param | Description | Type | Default
-------|------------|-------|---------
dockerRepoAuth | Enable registryCredentials | boolean | false
dockerRepoUsername | The registry username | String | null
dockerRepoPassword | The registry password | String | null
dockerRepoEmail | The registry email | String | null

This is for use with our internal docker repo.

Many Thanks