### PR TITLE
Changed println to logger.info

### DIFF
--- a/src/main/groovy/nebula/plugin/docker/NebulaDockerPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/docker/NebulaDockerPlugin.groovy
@@ -57,7 +57,7 @@ class NebulaDockerPlugin implements Plugin<Project>, Strings, NebulaDockerSensib
                 }
                 repository = repo
                 task.conventionMapping.tag = { taggingVersion }
-                println "Using version $taggingVersion"
+                logger.info "Using version $taggingVersion"
                 force = true
             }
 


### PR DESCRIPTION
When running this plugin in build we are seeing the output even if we use "gradle -q" which should suppress the output.
Println has been change to logger.info