### PR TITLE
Update build badge to use travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nebula Docker Plugin (Deprecated)
 
 ![Support Status](https://img.shields.io/badge/nebula-supported-brightgreen.svg)
-[![Build Status](https://travis-ci.org/nebula-plugins/nebula-docker-plugin.svg?branch=master)](https://travis-ci.org/nebula-plugins/nebula-docker-plugin)
+[![Build Status](https://travis-ci.com/nebula-plugins/nebula-docker-plugin.svg?branch=master)](https://travis-ci.com/nebula-plugins/nebula-docker-plugin)
 [![Coverage Status](https://coveralls.io/repos/nebula-plugins/nebula-docker-plugin/badge.svg?branch=master&service=github)](https://coveralls.io/github/nebula-plugins/nebula-docker-plugin?branch=master)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nebula-plugins/nebula-docker-plugin?utm_source=badgeutm_medium=badgeutm_campaign=pr-badge)
 [![Apache 2.0](https://img.shields.io/github/license/nebula-plugins/nebula-docker-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Although the title says this is deprecated, I see it's still marked as nebula supported and has been moved to travis-ci.com